### PR TITLE
Filtro pesquisa por vencimento

### DIFF
--- a/src/main/java/br/com/projeto/sistemadeavaliacao/controller/PerguntaController.java
+++ b/src/main/java/br/com/projeto/sistemadeavaliacao/controller/PerguntaController.java
@@ -30,7 +30,7 @@ public class PerguntaController {
 	@DiretorAnnotation
 	@RequestMapping("cadastrar")
 	public String cadPergunta(Model model) {
-		model.addAttribute("pesq", pesquisaRepository.findAll());
+		model.addAttribute("pesq", pesquisaRepository.filtroNaoVencidos());
 		return "pergunta/cadPergunta";
 	}
 

--- a/src/main/java/br/com/projeto/sistemadeavaliacao/repository/PesquisaRepository.java
+++ b/src/main/java/br/com/projeto/sistemadeavaliacao/repository/PesquisaRepository.java
@@ -5,12 +5,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface PesquisaRepository extends CrudRepository<Pesquisa, Long> {
     //busca as perguntas das pesquisas que tem perguntas a serem excluidas
     @Query("SELECT l FROM Pesquisa l INNER JOIN l.perguntaExclusao li where l.id = :id")
     public Pesquisa filtroExclusao(@Param("id") Long idPesquisa);
 
-    @Query("SELECT l FROM Pesquisa l where l.dataVencimento > CURRENT_DATE")
-    public Pesquisa filtroNaoVencidos();
+    @Query("SELECT l FROM Pesquisa l where l.dataVencimento > CURRENT_DATE order by l.id DESC")
+    public List<Pesquisa> filtroNaoVencidos();
 
 }

--- a/src/main/java/br/com/projeto/sistemadeavaliacao/repository/PesquisaRepository.java
+++ b/src/main/java/br/com/projeto/sistemadeavaliacao/repository/PesquisaRepository.java
@@ -10,4 +10,7 @@ public interface PesquisaRepository extends CrudRepository<Pesquisa, Long> {
     @Query("SELECT l FROM Pesquisa l INNER JOIN l.perguntaExclusao li where l.id = :id")
     public Pesquisa filtroExclusao(@Param("id") Long idPesquisa);
 
+    @Query("SELECT l FROM Pesquisa l where l.dataVencimento > CURRENT_DATE")
+    public Pesquisa filtroNaoVencidos();
+
 }


### PR DESCRIPTION
Na hora de cadastrar uma pergunta para uma pesquisa específica, as pesquisas disponíveis devem ser somente as que ainda não estão vencidas, ordenadas pelo ID de forma decrescente.

Filtro funcionando!