### PR TITLE
correcao curso

### DIFF
--- a/src/main/java/br/com/projeto/sistemadeavaliacao/model/TipoCurso.java
+++ b/src/main/java/br/com/projeto/sistemadeavaliacao/model/TipoCurso.java
@@ -2,17 +2,16 @@ package br.com.projeto.sistemadeavaliacao.model;
 
 public enum TipoCurso {
 
-	FIC("FIC"), CURSO_REGULAR("Curso Regular");
+	FIC("Fic"), CURSO_REGULARES("Curso_Regulares");
 
 	String TipoCr;
-
-	TipoCurso(String string) {
+	TipoCurso(String string){
 		this.TipoCr = string;
 	}
 
 	@Override
 	public String toString() {
-
-		return TipoCr;
+		// TODO Auto-generated method stub
+		return super.toString();
 	}
 }

--- a/src/main/resources/templates/curso/curso.html
+++ b/src/main/resources/templates/curso/curso.html
@@ -166,15 +166,12 @@
 			<select
 			  name="tipo"
 			  class="form-select"
-			  aria-label="Default select example"
-			>
-			  <option selected>Selecione o Tipo do Curso</option>
-			  <option
-				th:each="tipo : ${T(br.com.projeto.sistemadeavaliacao.model.TipoCurso).values()}"
+			  aria-label="Default select example" required="required">
+			  <option value="">Selecione o Tipo do Curso</option>
+			  <option th:each="tipo : ${T(br.com.projeto.sistemadeavaliacao.model.TipoCurso).values()}"
 				th:value="${tipo}"
 				th:text="${tipo}"
-				th:selected="${tipo.toString() == cs?.tipo?.toString()}"
-			  ></option>
+				th:selected="${tipo.toString() == cs?.tipo?.toString()}"></option>
 			</select>
 		  </div>
 		  <div class="mb-3 dv">

--- a/src/main/resources/templates/curso/listaCurso.html
+++ b/src/main/resources/templates/curso/listaCurso.html
@@ -108,7 +108,6 @@
 	<th class="th-height">Nome</th>
 	<th class="th-height">Tipo de Curso</th>
 	<th class="th-heightC">Alterar</th>
-	<th class="th-heightC">Excluir</th>
   </tr>
 </thead>
 <tbody id="tb-user" class="table-group-divider" >
@@ -119,9 +118,6 @@
 	
 	  <td><a type="button" class="btn btn-outline-dark" th:href="@{/alteraCurso(id=${c.id})}"><i
 		class="material-icons">create</i> </a></td>
-
-	<td><a type="button" class="btn btn-outline-dark" th:href="@{/exclueCurso(id=${c.id})}"> <i
-		class="material-icons">delete_forever</i></a></td> 	
  </tr>
  
 </tbody>


### PR DESCRIPTION
a lista de curso tinha a opcao de excluir o curso, e quando esse curso é atribuido a uma pesquisa nao é mais possivel apaga-lo.
removi a coluna excluir.

o tipo de curso como string estava dando erro na hora de cadastrar, voltei para o enum padrao.

o tipo de curso no cadastro de curso estava sem required, coloquei.